### PR TITLE
Low performance bug fix

### DIFF
--- a/sort.py
+++ b/sort.py
@@ -119,7 +119,11 @@ class KalmanBoxTracker(object):
         CY = (bbox[1]+bbox[3])//2
         self.centroidarr.append((CX,CY))
         self.bbox_history.append(bbox)
-    
+        if len(self.centroidarr) > 15:
+            self.centroidarr.pop(0)
+        if len(self.bbox_history) > 15:
+            self.bbox_history.pop(0)
+
     def predict(self):
         """
         Advances the state vector and returns the predicted bounding box estimate


### PR DESCRIPTION
The trajectory illustrate of the vehicle should set a limit. My test data is video that recorded in the city. I realize that if some vehicle stops over 10000 frames in the video, and none of the bbox_history is deleted until the object totally leaves the video. This would cause the detection process get incrediblely slow. Not to mention there's more than 10 car stops in the frame at the same time. 
(The number should be adjust by the complexity in the video, but I think 15~30 are the fair numbers in my case.)